### PR TITLE
Use `--debug` and `--party` as boolean flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,24 @@
 
 This CLI tool provides a quick way to flash Standard Firmata to your Arduino board.
 
-Supported boards:
+## Install
+
+1. Install NodeJS from [nodejs.org](http://nodejs.org)
+2. Run `npm install -g firmata-party` in your shell of choice
+
+## Usage
+
+```bash
+usage: firmata-party [<arduino name> | list] [--party] [--debug]
+
+firmata-party list # list all supported boards
+firmata-party uno # flash Standard Firmata to an Arduino Uno
+firmata-party uno --debug # show debug info
+firmata-party uno --party # keep flashing firmata on new arduinos until you quit the program with ctrl+c!
+firmata-party help # show usage info
+```
+
+## Supported boards:
 
 + **Arduino Uno**
 + **Arduino Mega**
@@ -16,22 +33,3 @@ Supported boards:
 + **Tinyduino**
 + **Sparkfun Pro Micro**
 + **Qtechknow Qduino**
-
-## How to install
-
-1. Install NodeJS from [nodejs.org](http://nodejs.org)
-2. Run `npm install -g firmata-party` in your shell of choice
-
-
-## How to use
-
-Run the following on your shell to flash Standard Firmata to an Arduino Uno:
-
-`firmata-party uno` or `firmata-party uno --debug` to see debug info while it runs.
-
-Substitute `uno` if you have a different board to an Arduino Uno. Running `firmata-party list` will list the keyword to use for all supported boards.
-
-## Party Mode
-`firmata-party --party uno`
-
-Keep flashing firmata on new arduinos until you quit the program with ctrl+c!

--- a/bin/firmata-party.js
+++ b/bin/firmata-party.js
@@ -5,34 +5,35 @@ var supportedBoards = require('../node_modules/avrgirl-arduino/boards.js').byNam
 var _ = require('underscore');
 var keypress = require('keypress');
 var argv = require('minimist')(process.argv.slice(2), opts = {
-  boolean: ['party', 'debug']
+  boolean: ['party', 'debug', 'help']
 });
 
-var arduino = argv._[0];
 var debugMode = argv.debug;
 var partyMode = argv.party;
-var help = 'usage: firmata-party <arduino name> [--party] [--debug]';
+var helpMsg = 'usage: firmata-party [<arduino name> | <command>] [--party] [--debug]';
 var supported = _.keys(supportedBoards).join(', ');
 
 function showHelp() {
-  console.log(help);
+  console.log(helpMsg);
 }
 
 function showSupported() {
   console.log('supported board flags: \n' + supported);
 }
 
-handleInput(arduino);
+handleArgs(argv);
 
-function handleInput(board) {
-  if (!board || board === 'help' || board === 'man') {
+function handleArgs(argv) {
+  var board = argv._[0];
+  var args = argv._;
+
+  if (!argv || args.indexOf('help') > -1 || args.indexOf('man') > -1) {
     var status = board ? 0 : 1;
     showHelp();
     return process.exit(status);
-  } else if (!_.has(supportedBoards, board)) {
-    var status = (board === 'list') ? 0 : 1;
+  } else if (args.indexOf('list') > -1) {
     showSupported();
-    return process.exit(status);
+    return process.exit(0);
   } else if (partyMode) {
     party({board: board, debug: debugMode});
   } else {

--- a/bin/firmata-party.js
+++ b/bin/firmata-party.js
@@ -1,15 +1,15 @@
 #!/usr/bin/env node
 var Avrgirl = require('avrgirl-arduino');
-var parseArgs = require('minimist');
 var path = require('path');
 var supportedBoards = require('../node_modules/avrgirl-arduino/boards.js').byName;
 var _ = require('underscore');
 var keypress = require('keypress');
+var argv = require('minimist')(process.argv.slice(2), opts = {
+  boolean: ['party', 'debug']
+});
 
-var args = (process.argv.slice(2));
-var argv = parseArgs(args, opts={})
 var arduino = argv._[0];
-var debug = argv.debug;
+var debugMode = argv.debug;
 var partyMode = argv.party;
 var help = 'usage: firmata-party <arduino name> [--party] [--debug]';
 var supported = _.keys(supportedBoards).join(', ');
@@ -34,9 +34,9 @@ function handleInput(board) {
     showSupported();
     return process.exit(status);
   } else if (partyMode) {
-    party({board: board, debug: debug});
+    party({board: board, debug: debugMode});
   } else {
-    flashAndQuit({board: board, debug: debug});
+    flashAndQuit({board: board, debug: debugMode});
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "firmata-party",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "set up your arduino with firmata and party on, robot friends.",
   "main": "firmata-party.js",
   "bin": {


### PR DESCRIPTION
expected: `firmata-party --party uno` and `firmata-party uno --party` should do the same thing
actual: `firmata-party uno --party` brings up usage documentation / fails

Turning on the boolean option and defining flags that are just booleans fixes this
`argv` without boolean option: `{ _: [], party: true, debug: 'uno' }`
`argv` with boolean option: `{ _: [ 'uno' ], party: true, debug: true }`

This PR enables the boolean option for `minimist` to ensure order of arguments doesn't matter and
- updates readme
- improves how flags and commands like `list` are handled
