### PR TITLE
Show help when zero args are supplied

### DIFF
--- a/bin/firmata-party.js
+++ b/bin/firmata-party.js
@@ -10,7 +10,14 @@ var argv = require('minimist')(process.argv.slice(2), opts = {
 
 var debugMode = argv.debug;
 var partyMode = argv.party;
-var helpMsg = 'usage: firmata-party [<arduino name> | <command>] [--party] [--debug]';
+var helpMsg = `usage: firmata-party [<arduino name> | <command>] [--party] [--debug]
+
+firmata-party list # list all supported boards
+firmata-party uno # flash Standard Firmata to an Arduino Uno
+firmata-party uno --debug # show debug info
+firmata-party uno --party # keep flashing firmata on new arduinos until you quit the program with ctrl+c!
+firmata-party help # show usage info
+`;
 var supported = _.keys(supportedBoards).join(', ');
 
 function showHelp() {

--- a/bin/firmata-party.js
+++ b/bin/firmata-party.js
@@ -26,8 +26,7 @@ handleArgs(argv);
 function handleArgs(argv) {
   var board = argv._[0];
   var args = argv._;
-
-  if (!argv || args.indexOf('help') > -1 || args.indexOf('man') > -1) {
+  if (!argv || args.length == 0 || args.indexOf('help') > -1 || args.indexOf('man') > -1) {
     var status = board ? 0 : 1;
     showHelp();
     return process.exit(status);


### PR DESCRIPTION
I'm no JavaScript guru and I don't know how portable the ES6 extended string literals are, let me know if I should change that.
