### PR TITLE
Update / sync boards list with avrgirl-arduino #63

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,8 +31,13 @@ Note that the port will be auto-detected except in the case of the Pro Mini (see
 + **Arduino Nano**
 + **Arduino Duemilanove (168)**
 + **Arduino Pro Mini**
++ **Arduino Lilypad USB**
++ **Arduino Yun**
 + **Femtoduino IMUduino**
-+ **Blend-Micro**
++ **RedBearLab Blend Micro**
 + **Tinyduino**
 + **Sparkfun Pro Micro**
 + **Qtechknow Qduino**
++ **Pinoccio Scout**
++ **Adafruit Feather 32u4 Basic Proto**
++ **Arduboy**

--- a/boards.js
+++ b/boards.js
@@ -102,6 +102,22 @@ var boards = {
     productId: ['0x0042', '0x6001', '0x0010'],
     protocol: 'stk500v2'
   },
+  'adk': {
+    baud: 115200,
+    signature: new Buffer([0x1e, 0x98, 0x01]), // ATmega2560
+    pageSize: 256,
+    delay1: 10,
+    delay2: 1,
+    timeout:0xc8,
+    stabDelay:0x64,
+    cmdexeDelay:0x19,
+    synchLoops:0x20,
+    byteDelay:0x00,
+    pollValue:0x53,
+    pollIndex:0x03,
+    productId: ['0x0044', '0x6001', '0x003F'],
+    protocol: 'stk500v2'
+  },
   'sf-pro-micro': {
     baud: 57600,
     signature: new Buffer([0x43, 0x41, 0x54, 0x45, 0x52, 0x49, 0x4e]),
@@ -138,6 +154,18 @@ var boards = {
     pollIndex:0x03,
     productId: ['0x6051'],
     protocol: 'stk500v2'
+  },
+  'lilypad-usb': {
+    baud: 57600,
+    signature: new Buffer([0x43, 0x41, 0x54, 0x45, 0x52, 0x49, 0x4e]),
+    productId: ['0x9207', '0x9208', '0x1B4F'],
+    protocol: 'avr109'
+  },
+  'yun': {
+    baud: 57600,
+    signature: new Buffer([0x43, 0x41, 0x54, 0x45, 0x52, 0x49, 0x4e]),
+    productId: ['0x0041', '0x8041'],
+    protocol: 'avr109'
   }
 };
 


### PR DESCRIPTION
Update the list of supported boards on both README.md and boards.js. Now in synced with the boards that avrgirl-arduino currently supports.