### PR TITLE
Fix an issue with avrgirl-arduino path resolution

### DIFF
--- a/bin/firmata-party.js
+++ b/bin/firmata-party.js
@@ -53,7 +53,7 @@ function handleArgs(argv) {
     if (args.length > 1) {
       options["port"] = args[1]
     }
-    
+
     if (partyMode) {
       party(options);
     } else {
@@ -64,8 +64,9 @@ function handleArgs(argv) {
 
 function flash(options, callback) {
   var avrgirl = new Avrgirl(options);
-  
-  var firmataDir = path.resolve(__dirname, '..', 'node_modules', 'avrgirl-arduino', 'junk', 'hex', options.board);
+
+  var avrgirlDir = path.dirname(require.resolve('avrgirl-arduino'));
+  var firmataDir = path.resolve(avrgirlDir, 'junk', 'hex', options.board);
   var firmataPath;
 
   fs.readdir(firmataDir, function(err, files) {


### PR DESCRIPTION
This will resolve #70, I believe. I tested it out using an `npm run firmata` script to replicate the issue, and it no longer occurs after this change.

It uses `require.resolve()` as specified inside https://github.com/noopkat/firmata-party/issues/70#issuecomment-325205456 to locate the correct installation directory for `avrgirl-arduino`. 